### PR TITLE
오타 수정, 진급 트리 번역 추가

### DIFF
--- a/(2a) Community Balance Overhaul INT/Balance Changes/Text/ko_KR/NewText.xml
+++ b/(2a) Community Balance Overhaul INT/Balance Changes/Text/ko_KR/NewText.xml
@@ -12,7 +12,7 @@
 			<Text>Ruling with an iron fist generally means to require absolute control when managing other people, often in the workplace. The saying can also refer to situations such as child-rearing or styles of government. This idiom is often used to describe the actions and practices of managers, parents, or leaders who give their subordinates little if any freedom of choice or input regarding decisions. Reasons for ruling with an iron fist can often depend on individual circumstances, such as inexperienced workers or unruly children. The effectiveness of using total control can also vary, depending on the scope of the management style and the situation.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_POLICY_UNIVERSAL_HEALTHCARE_F_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]국민 의료보험[ENDCOLOR]: 모든 도시에 [COLOR_YELLOW]호텔[ENDCOLOR]을 무료로 제공합니다. [ICON_CITIZEN]시민이 증가할 때 [ICON_CULTURE]문화를 [COLOR_POSITIVE_TEXT]50[ENDCOLOR] [COLOR:105:105:105:255](시대별 보정)[ENDCOLOR] 제공합니다.</Text>
+			<Text>[COLOR_POSITIVE_TEXT]국민 의료보험[ENDCOLOR]: 모든 도시에 [COLOR_YELLOW]병원[ENDCOLOR]을 무료로 제공합니다. [ICON_CITIZEN]시민이 증가할 때 [ICON_CULTURE]문화를 [COLOR_POSITIVE_TEXT]50[ENDCOLOR] [COLOR:105:105:105:255](시대별 보정)[ENDCOLOR] 제공합니다.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_POLICY_UNIVERSAL_HEALTHCARE_F">
 			<Text>국민 의료보험</Text>

--- a/(7bL) UI - Promotion Tree for VP Localized (v 1)/(7bL) UI - Promotion Tree for VP Localized (v 1).modinfo
+++ b/(7bL) UI - Promotion Tree for VP Localized (v 1)/(7bL) UI - Promotion Tree for VP Localized (v 1).modinfo
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Mod id="dbf896aa-27fd-4510-87d7-f797391250db" version="1">
+  <Properties>
+    <Name>(7bL) UI - Promotion Tree for VP Localized</Name>
+    <Teaser>[COLOR_GREEN]Translation of Community Balance Overhaul - Promotion Tree for VP[ENDCOLOR]</Teaser>
+    <Description>(7b) UI - Promotion Tree for VP Localization.
+Supported langauge : Korean</Description>
+    <Authors>80rokwoc4j</Authors>
+    <SpecialThanks>William Howard and VP team</SpecialThanks>
+    <HideSetupGame>0</HideSetupGame>
+    <AffectsSavedGames>0</AffectsSavedGames>
+    <SupportsSinglePlayer>1</SupportsSinglePlayer>
+    <SupportsMultiplayer>1</SupportsMultiplayer>
+    <SupportsHotSeat>1</SupportsHotSeat>
+    <SupportsMac>1</SupportsMac>
+    <ReloadAudioSystem>0</ReloadAudioSystem>
+    <ReloadLandmarkSystem>0</ReloadLandmarkSystem>
+    <ReloadStrategicViewSystem>0</ReloadStrategicViewSystem>
+    <ReloadUnitSystem>0</ReloadUnitSystem>
+  </Properties>
+  <Dependencies>
+    <Mod id="1f0a153b-26ae-4496-a2c0-a106d9b43c95" minversion="22" maxversion="22" title="(7b) UI - Promotion Tree for VP" />
+  </Dependencies>
+  <References />
+  <Blocks />
+  <Files>
+    <File md5="A9DDC0F286DF6D6A27A1EAD3128600E6" import="0">XML/UIPromotionTree.xml</File>
+  </Files>
+  <Actions>
+    <OnModActivated>
+      <UpdateDatabase>XML/UIPromotionTree.xml</UpdateDatabase>
+    </OnModActivated>
+  </Actions>
+</Mod>

--- a/(7bL) UI - Promotion Tree for VP Localized (v 1)/(7bL) UI - Promotion Tree for VP Localized (v 1).modinfo
+++ b/(7bL) UI - Promotion Tree for VP Localized (v 1)/(7bL) UI - Promotion Tree for VP Localized (v 1).modinfo
@@ -4,7 +4,7 @@
     <Name>(7bL) UI - Promotion Tree for VP Localized</Name>
     <Teaser>[COLOR_GREEN]Translation of Community Balance Overhaul - Promotion Tree for VP[ENDCOLOR]</Teaser>
     <Description>(7b) UI - Promotion Tree for VP Localization.
-Supported langauge : Korean</Description>
+ Supported langauge : Korean</Description>
     <Authors>80rokwoc4j</Authors>
     <SpecialThanks>William Howard and VP team</SpecialThanks>
     <HideSetupGame>0</HideSetupGame>

--- a/(7bL) UI - Promotion Tree for VP Localized (v 1)/XML/UIPromotionTree.xml
+++ b/(7bL) UI - Promotion Tree for VP Localized (v 1)/XML/UIPromotionTree.xml
@@ -1,0 +1,104 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<GameData>
+	<Language_ko_KR>
+		<Row Tag="TXT_KEY_PROMO_INTERCEPTION_TOOL_TIP" >
+			<Text>요격 범위 능력이 있는 게임 후반에만 선택할 수 있습니다.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_EVASION_TOOL_TIP" >
+			<Text>스텔스 폭격기는 선택할 수 없습니다.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_MELEE" >
+			<Text>근접 유닛</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_GUN" >
+			<Text>화약 유닛</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_MOUNTED" >
+			<Text>기병 유닛</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_ARMOR" >
+			<Text>기갑 유닛</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_RECON" >
+			<Text>정찰 유닛</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_ARCHER" >
+			<Text>원거리 보병 유닛</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_MOUNTED_ARCHER" >
+			<Text>원거리 기병 유닛</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_HELICOPTER" >
+			<Text>헬리콥터</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_SIEGE" >
+			<Text>공성 무기</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_AA" >
+			<Text>대공 무기</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_FIGHTER" >
+			<Text>전투기</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_BOMBER" >
+			<Text>폭격기</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_NAVALMELEE" >
+			<Text>근접 해군 유닛</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_NAVALRANGED" >
+			<Text>원거리 해군 유닛</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_CARRIER" >
+			<Text>항공모함</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_MOD_DESC_SUBMARINE" >
+			<Text>잠수함</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_SWITCH_MODE" >
+			<Text>모드 변경</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_DIPLO_CORNER_HOOK" >
+			<Text>진급 트리</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_DIPLO_CORNER_HOOK_TT" >
+			<Text>군사 유닛이 선택 가능한 진급을 쉽게 볼 수 있도록 표시합니다. (정찰, 해군, 근접, 공성, 등등)</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_OPEN_TREE_FOR_UNIT_TT" >
+			<Text>이 유닛이 선택 가능한 진급을 쉽게 볼 수 있도록 표시합니다.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_SIZE" >
+			<Text>작게 표시 (단축키: 'D')</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_EARNT" >
+			<Text>선택함</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_EARNT_TT" >
+			<Text>이미 이 유닛이 선택한 진급 (특수진급과 불가사의로 얻는 진급 제외)</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_AVAILABLE" >
+			<Text>선택 가능</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_AVAILABLE_TT" >
+			<Text>이 유닛이 선택할 수 있는 진급</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_NOT_AVAILABLE" >
+			<Text>아직 선택할 수 없음</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_NOT_AVAILABLE_TT" >
+			<Text>이 유닛이 아직 선택할 수 없는 진급</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_GROUP_UNIT" >
+			<Text>유닛</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_GROUP_CLASS" >
+			<Text>유닛 분류</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_GROUP_BASE" >
+			<Text>진급 트리</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PROMO_GROUP_BASE_TT" >
+			<Text>왼쪽 상단에 위치한 라디오 버튼 혹은 단축키 'D' 를 통해 모드를 바꿀 수 있습니다.</Text>
+		</Row>
+	</Language_ko_KR>
+</GameData>


### PR DESCRIPTION
평등에 2티어 정책 국민 의료보험 무료 호텔에서 무료 병원으로 수정, 진급 트리 번역 추가.
모드 구동엔 문제 없으나 네이밍 컨벤션이 조금 다르고
CBO 번역 모드에 modinfo 파일 해쉬값이 다를것으로 예상.